### PR TITLE
main.go: arachnid -> Arachnid

### DIFF
--- a/evmdis/main.go
+++ b/evmdis/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/arachnid/evmdis"
+	"github.com/Arachnid/evmdis"
 )
 
 func main() {


### PR DESCRIPTION
`go` couldn't build/install otherwise for me.

* Arch Linux;
* go version `go1.6.3 linux/amd64`.