### PR TITLE
CALL instructions are no longer lifted of the stack if the result is consumed only once and in the same block

### DIFF
--- a/evmdis/main.go
+++ b/evmdis/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -32,10 +33,14 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("Could not read from stdin: %v", err))
 	}
+	hexdata = bytes.TrimSpace(hexdata)
 
 	// disassemble
 	bytecode := make([]byte, hex.DecodedLen(len(hexdata)))
-	hex.Decode(bytecode, hexdata)
+	_, err = hex.Decode(bytecode, hexdata)
+	if err != nil {
+		panic(fmt.Sprintf("Could not decode hex string: %v", err))
+	}
 
 	if disassembly, err := Disassemble(bytecode, *withSwarmHash, *ctorMode); err != nil {
 		panic(fmt.Sprintf("Unable to disassemble: %v", err))

--- a/expressions.go
+++ b/expressions.go
@@ -287,7 +287,7 @@ func BuildExpressions(prog *Program) error {
 
 				var reaches ReachesDefinition
 				inst.Annotations.Get(&reaches)
-				if len(reaches) == 1 && reaches[0].OriginBlock == block {
+				if len(reaches) == 1 && reaches[0].OriginBlock == block && !inst.Op.HasSideEffects() {
 					// 'Lift' this definition out of the stack, since we know it'll be consumed
 					// later in this block (and only there)
 					ptr := InstructionPointer{block, i}

--- a/expressions.go
+++ b/expressions.go
@@ -78,10 +78,16 @@ func (self *InstructionExpression) String() string {
 	}
 }
 
-type PopExpression struct{}
+type PopExpression struct{
+	Inst      *InstructionPointer
+}
 
 func (self *PopExpression) String() string {
-	return "POP()"
+	if self.Inst != nil {
+		return "POP("+self.Inst.String()+")"
+	} else {
+		return "POP()"
+	}
 }
 
 func (self *PopExpression) Eval() *big.Int {
@@ -270,7 +276,12 @@ func BuildExpressions(prog *Program) error {
 							// If there's more than one definition reaching the argument
 							// or it's not in our set of expression fragments, represent it
 							// as a stack pop.
-							args = append(args, &PopExpression{})
+							var expression = &PopExpression{}
+							if len(pointers) == 1 {
+								expression.Inst = pointers.First()
+							}
+							var converted = Expression(expression)
+							args = append(args, converted)
 						} else {
 							// Inline this argument's expression
 							sourcePointer := pointers.First()

--- a/expressions.go
+++ b/expressions.go
@@ -220,26 +220,25 @@ func BuildExpressions(prog *Program) error {
 				swapFrom, swapTo := reaching[0], reaching[len(reaching)-1]
 				leftLifted := len(swapFrom) == 1 && lifted[*swapFrom.First()]
 				rightLifted := len(swapTo) == 1 && lifted[*swapTo.First()]
+                                if leftLifted {
+                                    delete(lifted, *swapFrom.First())
+                                }
+                                if rightLifted {
+                                    delete(lifted, *swapTo.First())
+                                }		
+				count := 0
 				if len(reaching) > 2 || (!leftLifted && !rightLifted) {
-					// One side only is lifted; resolve by making arg explicit again
-					if leftLifted && !rightLifted {
-						delete(lifted, *swapFrom.First())
-					} else if !leftLifted && rightLifted {
-						delete(lifted, *swapTo.First())
-					}
-
 					if !leftLifted || !rightLifted {
 						// Count number of non-lifted elements between the operands
-						count := 0
 						for i := 1; i < len(reaching)-1; i++ {
 							if len(reaching[i]) != 1 || !lifted[*reaching[i].First()] {
 								count += 1
 							}
 						}
-						var expression Expression = &SwapExpression{count + 1}
-						inst.Annotations.Set(&expression)
 					}
 				}
+				var expression Expression = &SwapExpression{count + 1}
+				inst.Annotations.Set(&expression)				
 			} else if inst.Op.IsDup() {
 				// Try and reduce the size of dup operations to account for lifted arguments
 

--- a/opcodes.go
+++ b/opcodes.go
@@ -14,6 +14,14 @@ func (op OpCode) IsPush() bool {
 	return false
 }
 
+func (op OpCode) HasSideEffects() bool {
+	switch op {
+	case CALL:
+		return true
+	}
+	return false
+}
+
 func (op OpCode) IsDup() bool {
 	switch op {
 	case DUP1, DUP2, DUP3, DUP4, DUP5, DUP6, DUP7, DUP8, DUP9, DUP10, DUP11, DUP12, DUP13, DUP14, DUP15, DUP16:


### PR DESCRIPTION
If a CALL instruction was followed by a POP instruction the corresponding evmdis output would look like this:

___0xE5	POP(CALL(POP(), POP(), POP(), POP(), POP(), POP(), POP()))___

This PR changes the output for those cases to this:

___0xE4	PUSH(CALL(POP(), POP(), POP(), POP(), POP(), POP(), POP()))___
___0xE5	POP()___

I used this contract for testing:

`6060604052361560275760e060020a600035046341c0e1b581146075578063e522538114609f575b60eb6000341115607357604080513481529051605891600160a060020a033316917f90890809c654f11d6e72a28fa60149770a0d11ec6c92319d6ceb2bb0a4ea1a159181900360200190a35b565b3460025760eb60005433600160a060020a0390811691161415607357600054600160a060020a0316ff5b3460025760eb60005433600160a060020a039081169116141560735760008054604051600160a060020a0391821692309092163180156108fc0292909190818181858888f15050505050565b00`



